### PR TITLE
Add from/to raw parts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,22 @@ pub struct Gc<T> {
     _phantom: std::marker::PhantomData<*mut T>,
 }
 
+impl<T> Gc<T> {
+    /// Create a new `Gc<T>` from a raw heap ID and index.
+    pub fn from_raw_parts(heap_id: u32, index: u32) -> Self {
+        Self {
+            heap_id,
+            index,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Get the raw heap ID and index from a `Gc<T>`.
+    pub fn into_raw_parts(self) -> (u32, u32) {
+        (self.heap_id, self.index)
+    }
+}
+
 impl<T> Clone for Gc<T> {
     fn clone(&self) -> Self {
         *self


### PR DESCRIPTION
I'm using `safe-gc` for my toy programming language called `atom`. As we are using NaN tagging it would be great if a `Gc<T>` can be converted from/to the two `u32` pairs. This way we can efficiently store values.